### PR TITLE
Highlight drop location on the slot instead on the widget.

### DIFF
--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragDropUtil.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragDropUtil.java
@@ -14,7 +14,7 @@
 package fi.jasoft.dragdroplayouts.client.ui;
 
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.MouseEventDetailsBuilder;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayout.java
@@ -229,16 +229,19 @@ public class VDDHorizontalLayout extends VHorizontalLayout implements VHasDragMo
 
     currentlyEmphasised = container;
 
-    UIObject.setStyleName(container.getElement(), OVER, true);
-
+    HorizontalDropLocation location = null;
+    
     // Add drop location specific style
-    if (container.getElement().equals(this.getElement())) {
-      UIObject.setStyleName(container.getElement(), OVER + "-"
-          + HorizontalDropLocation.CENTER.toString().toLowerCase(), true);
+    if (currentlyEmphasised != this) {
+        location = getHorizontalDropLocation(container, event);
+
     } else {
-      UIObject.setStyleName(container.getElement(),
-          OVER + "-" + getHorizontalDropLocation(container, event).toString().toLowerCase(), true);
+        location = HorizontalDropLocation.CENTER;
     }
+    
+    UIObject.setStyleName(currentlyEmphasised.getElement(), OVER, true);
+    UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+            + location.toString().toLowerCase(), true);
   }
 
   /**

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayoutDropHandler.java
@@ -73,7 +73,7 @@ public class VDDHorizontalLayoutDropHandler extends VDDAbstractDropHandler<VDDHo
       public void accepted(VDragEvent event) {
         Slot slot = getSlot(event.getElementOver());
         if (slot != null) {
-          getLayout().emphasis(slot.getWidget(), event);
+          getLayout().emphasis(slot, event);
         } else {
           getLayout().emphasis(getLayout(), event);
         }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayout.java
@@ -189,16 +189,19 @@ public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
 
     currentlyEmphasised = container;
 
-    UIObject.setStyleName(container.getElement(), OVER, true);
-
+    VerticalDropLocation location = null;
+    
     // Add drop location specific style
-    if (container != this) {
-      UIObject.setStyleName(container.getElement(),
-          OVER + "-" + getVerticalDropLocation(container, event).toString().toLowerCase(), true);
+    if (currentlyEmphasised != this) {
+        location = getVerticalDropLocation(currentlyEmphasised, event);
+
     } else {
-      UIObject.setStyleName(container.getElement(), OVER + "-"
-          + VerticalDropLocation.MIDDLE.toString().toLowerCase(), true);
+        location = VerticalDropLocation.MIDDLE;
     }
+    
+    UIObject.setStyleName(currentlyEmphasised.getElement(), OVER, true);
+    UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+            + location.toString().toLowerCase(), true);
   }
 
   /**

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayoutDropHandler.java
@@ -73,7 +73,7 @@ public class VDDVerticalLayoutDropHandler extends VDDAbstractDropHandler<VDDVert
       public void accepted(VDragEvent event) {
         Slot slot = getSlot(event.getElementOver());
         if (slot != null) {
-          getLayout().emphasis(slot.getWidget(), event);
+          getLayout().emphasis(slot, event);
         } else {
           getLayout().emphasis(getLayout(), event);
         }

--- a/addon/src/main/resources/fi/jasoft/dragdroplayouts/DragDropLayoutsWidgetSet.gwt.xml
+++ b/addon/src/main/resources/fi/jasoft/dragdroplayouts/DragDropLayoutsWidgetSet.gwt.xml
@@ -3,7 +3,7 @@
 <!-- WS Compiler: manually edited -->
 <module>
         <inherits name="com.vaadin.DefaultWidgetSet" />
-        <set-property name="user.agent" value="ie8,ie9,gecko1_8,safari,opera,ie10" />
+        <set-property name="user.agent" value="ie8,ie9,gecko1_8,safari,ie10" />
         <source path="client" />
         <source path="shared" />
         <stylesheet src="fi_jasoft_dragdroplayouts/dragdroplayouts.css" />

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ project(':addon'){
     vaadin {
         widgetset = 'fi.jasoft.dragdroplayouts.DragDropLayoutsWidgetSet'
 
+				gwt {
+					userAgent = 'ie8,ie9,gecko1_8,safari,ie10'
+				}
+
         addon {
             author 'John Ahlroos'
             license 'Apache 2.0'
@@ -41,9 +45,9 @@ project(':addon'){
         }
         manifest { // the manifest of the default jar is of type OsgiManifest
             name = 'dragdroplayouts'
-/* 
+/*
   it seems we need to export the client-side stuff too to make it easier to include the jar file as project dependency
-            instruction 'Export-Package', '!fi.jasoft.dragdroplayouts.client.*', '*' 
+            instruction 'Export-Package', '!fi.jasoft.dragdroplayouts.client.*', '*'
 */
 	    instruction 'Import-Package', '!com.google.gwt.*', '!com.vaadin.client.*', '*'
             instruction 'Bundle-Vendor', 'johndevs'
@@ -85,7 +89,7 @@ project(':demo'){
 
 	plugin {
 		logToConsole true
-	}	
+	}
 
     }
 


### PR DESCRIPTION
On Vertical and Horizontal layout, the drop location is highlighted and provided relative to layout slots instead of components inside the layout.