### PR TITLE
Fix DDPanel update on client changes.

### DIFF
--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/DDPanelConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/DDPanelConnector.java
@@ -47,6 +47,7 @@ public class DDPanelConnector extends PanelConnector implements VHasDragFilter {
 
     @Override
     public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
+        super.updateFromUIDL(uidl, client);
         VDDPanelDropHandler dropHandler = new VDDPanelDropHandler(this);
         VDragDropUtil.updateDropHandlerFromUIDL(uidl, this, dropHandler);
         if (html5Support != null) {


### PR DESCRIPTION
DDPanel cannot be updated because parent's updateFromUIDL call is missing for some reason.