### PR TITLE
Fixes NPE in HTML5Support.validate method

### DIFF
--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/util/HTML5Support.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/util/HTML5Support.java
@@ -163,6 +163,9 @@ public class HTML5Support {
 
             Element target = Element.as(event.getEventTarget());
             Widget widget = Util.findWidget(target, null);
+            if (widget == null) {
+                return false;
+            }
 
             ComponentConnector connector = Util.findConnectorFor(widget);
             while (connector == null) {


### PR DESCRIPTION
Probably bug occurs when trying to dnd non-widget element.