### PR TITLE
Make compatible with current Vaadin master (will be Vaadin 7.7)

### DIFF
--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDGridLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDGridLayout.java
@@ -250,7 +250,6 @@ public class DDGridLayout extends GridLayout
      */
     @Override
     public void paintContent(PaintTarget target) throws PaintException {
-        super.paintContent(target);
         if (dropHandler != null && isEnabled()) {
             dropHandler.getAcceptCriterion().paint(target);
         }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/DDGridLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/DDGridLayoutConnector.java
@@ -49,7 +49,6 @@ public class DDGridLayoutConnector extends GridLayoutConnector
 
     @Override
     public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
-        super.updateFromUIDL(uidl, client);
         VDragDropUtil.updateDropHandlerFromUIDL(uidl, this, new VDDGridLayoutDropHandler(this));
         if (html5Support != null) {
             html5Support.disable();


### PR DESCRIPTION
Remove super.paintContent & super.updateFromUIDL calls as GridLayout does not implement LegacyComponent anymore:
https://github.com/vaadin/vaadin/commit/809440a8a2247d7f82945da572ab494d02639d72