### PR TITLE
Added DDSwapGridLayout, layout able to swap two occupied cells

### DIFF
--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDSwapGridLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDSwapGridLayout.java
@@ -1,0 +1,109 @@
+package be.beme.schn.vaadin.dd;
+
+
+import com.vaadin.ui.Component;
+import com.vaadin.ui.CustomComponent;
+import com.vaadin.ui.DragAndDropWrapper;
+import com.vaadin.ui.GridLayout;
+
+/**
+ * A GridLayout that handles the drag and drop by the way of
+ * swapping to child, but does not handle empty cells. For
+ * this purpose use DDDGridLayout
+ *
+ * @version 1.0
+ * @author Dorian Messina.
+ */
+public class DDSwapGridLayout extends CustomComponent {
+    private final GridLayout layout;
+    private final SwapGridLayoutDropHandler dropHandler;
+
+    public DDSwapGridLayout() {
+        layout = new GridLayout();
+        dropHandler = new SwapGridLayoutDropHandler(layout);
+
+        final DragAndDropWrapper pane = new DragAndDropWrapper(layout);
+        setCompositionRoot(pane);
+    }
+
+    /**
+     * @param component an item to add to the DDSwapGridLayout
+     * **/
+    public void addComponent(final Component component) {
+        final SwapDragAndDropWrapper wrapper = new SwapDragAndDropWrapper(component,
+                dropHandler);
+
+        layout.addComponent(wrapper);
+    }
+
+
+    public void addDropListener(Listener listener)
+    {
+
+       dropHandler.addDropListener(listener);
+
+    }
+
+    /**
+     * @return find a abscissa by index. Useful when you work somewhere with
+     * a List
+     * **/
+    public int findX(int index)
+    {
+        return index%layout.getColumns();
+    }
+    /**
+     * @return find a ordinate by index. Useful when you work somewhere with
+     * a List
+     * **/
+    public int findY(int index, int x)
+    {
+        return (index-x)/layout.getRows();
+    }
+
+    /**
+     * @return the GriLayout from the drag and drop system. Be careful don't use
+     * getGridLayout().getComponent(x,y), but instead {@link #getUnwrappedComponent(int x, int y)}.
+     */
+    public GridLayout getGridLayout()
+    {
+        return this.layout;
+    }
+
+    /**
+     * @return an item put by you in the GridLayout cleaned from drag and drop stuff
+     * **/
+    public Component getUnwrappedComponent(int x, int y){
+        SwapDragAndDropWrapper wrappedDrag=(SwapDragAndDropWrapper) this.layout.getComponent(x,y);
+        return wrappedDrag.getCompositionRoot();
+    }
+
+    //------------------------------------------------------------------\\
+
+    /**
+     * The wrapper to use with DDSzapGridLayout must be this one
+     * because it's used in {@link #getUnwrappedComponent(int x, int y)}
+     * **/
+    public class SwapDragAndDropWrapper extends DragAndDropWrapper {
+
+        private final DropHandler dropHandler;
+
+        public SwapDragAndDropWrapper(final Component content,
+                                      final DropHandler dropHandler) {
+            super(content);
+            this.dropHandler = dropHandler;
+            setDragStartMode(DragAndDropWrapper.DragStartMode.WRAPPER);
+
+        }
+
+        /**
+         * The purpose of this method is to make public the one from supper class
+         * DragAndDropWrapper. That way, we can call it in DDSwapGridLayout
+         * **/
+        public Component getCompositionRoot()
+        {
+            return super.getCompositionRoot();
+        }
+    }
+
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/drophandlers/DefaultSwapGridLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/drophandlers/DefaultSwapGridLayoutDropHandler.java
@@ -1,0 +1,95 @@
+package be.beme.schn.vaadin.dd;
+
+import com.vaadin.event.Transferable;
+import com.vaadin.event.dd.DragAndDropEvent;
+import com.vaadin.event.dd.DropHandler;
+import com.vaadin.event.dd.DropTarget;
+import com.vaadin.event.dd.TargetDetails;
+import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
+import com.vaadin.event.dd.acceptcriteria.Not;
+import com.vaadin.event.dd.acceptcriteria.SourceIsTarget;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.GridLayout;
+
+import java.util.ArrayList;
+
+/**
+ * @author  Dorian Messina.
+ */
+public class DefaultSwapGridLayoutDropHandler implements DropHandler {
+
+    private final GridLayout layout;
+    private int indexdest=0;
+    private int xdest;
+    private int ydest;
+    private int indexsrc=0;
+    private int xsrc;
+    private int ysrc;
+    private ArrayList<Component.Listener> listeners;
+
+    public DefaultSwapGridLayoutDropHandler(final GridLayout layout) {
+        this.layout = layout;
+        listeners=new ArrayList<>();
+    }
+
+    @Override
+    public AcceptCriterion getAcceptCriterion() {
+        return new Not(SourceIsTarget.get());
+    }
+
+    @Override
+    public void drop(final DragAndDropEvent dropEvent) {
+        final Transferable transferable = dropEvent.getTransferable();
+        final Component sourceComponent = transferable.getSourceComponent();
+
+        if (sourceComponent instanceof SwapDragAndDropWrapper)
+        {
+            final TargetDetails dropTargetData = dropEvent.getTargetDetails();
+            final DropTarget target = dropTargetData.getTarget();                                                       //DropTarget extends Component
+            int[] results=findComponent(target);
+            indexdest=results[0];
+            xdest=results[1];
+            ydest=results[2];
+
+            results=findComponent(sourceComponent);
+            indexsrc=results[0];
+            xsrc=results[1];
+            ysrc=results[2];
+
+            layout.replaceComponent(layout.getComponent(xdest,ydest),sourceComponent);
+        }
+
+        fireDropEvent();
+    }
+
+    private int[] findComponent(Component target)
+    {
+        int index=0;
+        for(int y=0;y<layout.getRows();y++)
+        {
+            for(int x=0;x<layout.getColumns();x++)
+            {
+
+                if(layout.getComponent(x,y)==target) //should I use .equals()?
+                {
+                    return new int[]{index,x,y};
+                }
+                index++;
+            }
+        }
+        return null;
+    }
+
+    public void addDropListener(Component.Listener listener)
+    {
+        listeners.add(listener);
+    }
+
+    public void fireDropEvent()
+    {
+        for(Component.Listener l: listeners)
+        {
+            l.componentEvent(new SwapGridLayoutDropEvent(this.layout,new int[]{xdest,ydest,indexdest,xsrc,ysrc,indexsrc}));
+        }
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/events/SwapGridLayoutDropEvent.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/events/SwapGridLayoutDropEvent.java
@@ -1,0 +1,57 @@
+package be.beme.schn.vaadin.dd;
+
+import com.vaadin.ui.Component;
+import com.vaadin.ui.GridLayout;
+
+/**
+ * Client side criterion for determining axis or indexes
+ * Event fired when an item is dropped from a cell to another
+ * in a {@link SwapDDGridLayout}
+ * @author  Dorian Messina.
+ */
+public class SwapGridLayoutDropEvent extends Component.Event {
+
+    private int[] coordinates;
+
+
+
+    /**
+     * Constructs a new event with the specified source component.
+     *
+     * @param source the GridLayout
+     * @param coordinates .
+     */
+    public SwapGridLayoutDropEvent(GridLayout source, int[] coordinates) {
+        super(source);
+        this.coordinates=coordinates;
+    }
+
+    /**
+     * @return the abscissa/column to where the item is dropped
+     * **/
+    public int getXdest() {return coordinates[0];}
+    /**
+     * @return the ordinate/row to where the item is dropped
+     * **/
+    public int getYdest() {return coordinates[1];}
+
+    /**
+     * @return index in the GridLayout where the component is dropped
+     */
+    public int getIndexdest() {return coordinates[2];}
+
+    /**
+     * @return the abscissa/column from where the item was dragged
+     * **/
+    public int getXsrc() {return coordinates[3];}
+    /**
+     * @return the ordinate/row from where the item was dragged
+     * **/
+    public int getYsrc() {return coordinates[4];}
+
+    /**
+     * @return index int the GridLayout from where the item was dragged
+     * **/
+    public int getIndexsrc() {return coordinates[5];
+    }
+}


### PR DESCRIPTION
According to the demo of the add-on, DDGridLayout swap an occupied cell with an empty one. In opposite, this new DDSwapGridLayout swap an occupied cell with another occupied. See the screenshot of a working example in attachement of the first post  [https://vaadin.com/forum#!/thread/13820707](url) I added the DropHandler and DropEvent in the right packages. However I use a custom DragAndDropWrapper in the puporse of to retrieve a component of the GridLayout, see getUnWrappedComponent method from DDGridLayout, I don't no if it is a good idea or the user should do it himself.
