### PR TITLE
Improve drag/grab control with DragGrabFilter and DragCaptionProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignored in root project
 .gradle
+.idea/
 
 #Ignored in all projects
 **/.classpath

--- a/addon/src/main/java/com/vaadin/server/ClientConnectorResources.java
+++ b/addon/src/main/java/com/vaadin/server/ClientConnectorResources.java
@@ -1,0 +1,13 @@
+package com.vaadin.server;
+
+/**
+ * Utility class to attach resources to any using protected method {@link AbstractClientConnector#setResource(String, Resource)}
+ */
+public final class ClientConnectorResources {
+    private ClientConnectorResources() {
+    }
+
+    public static void setResource(AbstractClientConnector component, String key, Resource resource) {
+        component.setResource(key, resource);
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDAbsoluteLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDAbsoluteLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -24,17 +22,13 @@ import com.vaadin.server.PaintTarget;
 import com.vaadin.ui.AbsoluteLayout;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.absolutelayout.DDAbsoluteLayoutState;
 import fi.jasoft.dragdroplayouts.details.AbsoluteLayoutTargetDetails;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Absolute layout with drag and drop support
@@ -44,7 +38,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDAbsoluteLayout extends AbsoluteLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragImageReferenceSupport, DragFilterSupport {
+        DragImageReferenceSupport, DragFilterSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     // Drop handler which handles dd drop events
     private DropHandler dropHandler;
@@ -52,7 +46,11 @@ public class DDAbsoluteLayout extends AbsoluteLayout
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
 
     /**
      * Creates an AbsoluteLayout with full size.
@@ -80,6 +78,16 @@ public class DDAbsoluteLayout extends AbsoluteLayout
         if (dropHandler != null && isEnabled()) {
             dropHandler.getAcceptCriterion().paint(target);
         }
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
     }
 
     /**
@@ -197,5 +205,15 @@ public class DDAbsoluteLayout extends AbsoluteLayout
     @Override
     public DragImageProvider getDragImageProvider() {
         return this.dragImageProvider;
+    }
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDAccordion.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDAccordion.java
@@ -13,9 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Iterator;
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -25,17 +22,14 @@ import com.vaadin.server.PaintTarget;
 import com.vaadin.ui.Accordion;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.accordion.DDAccordionState;
 import fi.jasoft.dragdroplayouts.details.AccordionTargetDetails;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Accordion with drag and drop support
@@ -46,7 +40,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDAccordion extends Accordion
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragImageReferenceSupport, DragFilterSupport {
+        DragImageReferenceSupport, DragFilterSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     /**
      * The drop handler which handles dropped components in the layout.
@@ -56,7 +50,11 @@ public class DDAccordion extends Accordion
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
 
     /**
      * Construct a new accordion
@@ -98,6 +96,17 @@ public class DDAccordion extends Accordion
         }
 
         return new LayoutBoundTransferable(this, rawVariables);
+    }
+
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
     }
 
     /**
@@ -231,5 +240,15 @@ public class DDAccordion extends Accordion
     @Override
     public DragImageProvider getDragImageProvider() {
         return this.dragImageProvider;
+    }
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDCssLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDCssLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -28,17 +26,13 @@ import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.csslayout.DDCssLayoutState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * CssLayout with drag and drop support
@@ -50,7 +44,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDCssLayout extends CssLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     // Drop handler which handles dd drop events
     private DropHandler dropHandler;
@@ -58,7 +52,11 @@ public class DDCssLayout extends CssLayout
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
 
     /**
      * Construct a new Css layout
@@ -75,6 +73,26 @@ public class DDCssLayout extends CssLayout
      */
     public DDCssLayout(Component... components) {
         super(components);
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
     }
 
     /**

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDFormLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDFormLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -27,17 +25,13 @@ import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.FormLayout;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.formlayout.DDFormLayoutState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Form layout with support for drag and drop
@@ -48,7 +42,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
  */
 public class DDFormLayout extends FormLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
     /**
      * The drop handler which handles dropped components in the layout.
      */
@@ -57,7 +51,31 @@ public class DDFormLayout extends FormLayout
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Contains the component over which the drop was made and the index on

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDGridLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDGridLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -28,17 +26,13 @@ import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.gridlayout.DDGridLayoutState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Grid layout with drag and drop support
@@ -49,14 +43,38 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDGridLayout extends GridLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     private DropHandler dropHandler;
 
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Target details for a drop event

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDHorizontalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDHorizontalLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -27,18 +25,14 @@ import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.horizontallayout.DDHorizontalLayoutState;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Horizontal layout with drag and drop support
@@ -49,7 +43,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDHorizontalLayout extends HorizontalLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     /**
      * The drop handler which handles dropped components in the layout.
@@ -59,7 +53,31 @@ public class DDHorizontalLayout extends HorizontalLayout
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Contains the component over which the drop was made and the index on

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDHorizontalSplitPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDHorizontalSplitPanel.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -27,17 +25,13 @@ import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalSplitPanel;
 import com.vaadin.ui.LegacyComponent;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.horizontalsplitpanel.DDHorizontalSplitPanelState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Horizontal split panel with drag and drop support
@@ -48,7 +42,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDHorizontalSplitPanel extends HorizontalSplitPanel
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     /**
      * The drop handler which handles dropped components in the layout.
@@ -58,7 +52,31 @@ public class DDHorizontalSplitPanel extends HorizontalSplitPanel
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Contains the location and other information about the drop.

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDPanel.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -26,21 +24,17 @@ import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
 import com.vaadin.ui.Panel;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.panel.DDPanelState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 public class DDPanel extends Panel
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     // Drop handler which handles dd drop events
     private DropHandler dropHandler;
@@ -48,7 +42,11 @@ public class DDPanel extends Panel
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
 
     /**
      * @see Panel#Panel()
@@ -76,6 +74,26 @@ public class DDPanel extends Panel
      */
     public DDPanel(String caption, Component content) {
         super(caption, content);
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
     }
 
     @SuppressWarnings("serial")

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDTabSheet.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDTabSheet.java
@@ -13,9 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Iterator;
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -28,17 +25,14 @@ import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
 import com.vaadin.ui.TabSheet;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.tabsheet.DDTabSheetState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Tabsheet with drag and drop support
@@ -49,7 +43,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDTabSheet extends TabSheet
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     /**
      * The drop handler which handles dropped components in the layout.
@@ -59,7 +53,31 @@ public class DDTabSheet extends TabSheet
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     public class TabSheetTargetDetails extends TargetDetailsImpl {
 

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDVerticalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDVerticalLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -27,17 +25,13 @@ import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
 import com.vaadin.ui.VerticalLayout;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.verticallayout.DDVerticalLayoutState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Vertical layout with drag and drop support
@@ -48,7 +42,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDVerticalLayout extends VerticalLayout
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
     /**
      * The drop handler which handles dropped components in the layout.
      */
@@ -57,7 +51,31 @@ public class DDVerticalLayout extends VerticalLayout
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Contains the component over which the drop was made and the index on

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DDVerticalSplitPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DDVerticalSplitPanel.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts;
 
-import java.util.Map;
-
 import com.vaadin.event.Transferable;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.DropTarget;
@@ -27,17 +25,13 @@ import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.LegacyComponent;
 import com.vaadin.ui.VerticalSplitPanel;
-
 import fi.jasoft.dragdroplayouts.client.ui.Constants;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.client.ui.verticalsplitpanel.DDVerticalSplitPanelState;
 import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
-import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
-import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
-import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+import fi.jasoft.dragdroplayouts.interfaces.*;
+
+import java.util.Map;
 
 /**
  * Vertical split panel with drag and drop support
@@ -48,7 +42,7 @@ import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
 @SuppressWarnings("serial")
 public class DDVerticalSplitPanel extends VerticalSplitPanel
         implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
-        DragFilterSupport, DragImageReferenceSupport {
+        DragFilterSupport, DragImageReferenceSupport, DragGrabFilterSupport, HasDragCaptionProvider {
 
     /**
      * The drop handler which handles dropped components in the layout.
@@ -58,7 +52,31 @@ public class DDVerticalSplitPanel extends VerticalSplitPanel
     // A filter for dragging components.
     private DragFilter dragFilter = DragFilter.ALL;
 
+    private DragGrabFilter dragGrabFilter;
+
     private DragImageProvider dragImageProvider;
+
+    private DragCaptionProvider dragCaptionProvider;
+
+    @Override
+    public DragGrabFilter getDragGrabFilter() {
+        return dragGrabFilter;
+    }
+
+    @Override
+    public void setDragGrabFilter(DragGrabFilter dragGrabFilter) {
+        this.dragGrabFilter = dragGrabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(DragCaptionProvider provider) {
+        this.dragCaptionProvider = provider;
+    }
+
+    @Override
+    public DragCaptionProvider getDragCaptionProvider() {
+        return dragCaptionProvider;
+    }
 
     /**
      * Contains the location and other information about the drop.

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2017 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts;
 
 import com.vaadin.server.Resource;
+import com.vaadin.shared.ui.ContentMode;
 
 /**
  * Drag caption definition: icon and caption.
@@ -8,10 +22,17 @@ import com.vaadin.server.Resource;
 public class DragCaption {
     protected String caption;
     protected Resource icon;
+    protected ContentMode contentMode = ContentMode.TEXT;
 
     public DragCaption(String caption, Resource icon) {
         this.caption = caption;
         this.icon = icon;
+    }
+
+    public DragCaption(String caption, Resource icon, ContentMode contentMode) {
+        this.caption = caption;
+        this.icon = icon;
+        this.contentMode = contentMode;
     }
 
     public Resource getIcon() {
@@ -28,5 +49,9 @@ public class DragCaption {
 
     public void setCaption(String caption) {
         this.caption = caption;
+    }
+
+    public ContentMode getContentMode() {
+        return contentMode;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
@@ -1,0 +1,29 @@
+package fi.jasoft.dragdroplayouts;
+
+import com.vaadin.server.Resource;
+
+public class DragCaption {
+    protected String caption;
+    protected Resource icon;
+
+    public DragCaption(String caption, Resource icon) {
+        this.caption = caption;
+        this.icon = icon;
+    }
+
+    public Resource getIcon() {
+        return icon;
+    }
+
+    public String getCaption() {
+        return caption;
+    }
+
+    public void setIcon(Resource icon) {
+        this.icon = icon;
+    }
+
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/DragCaption.java
@@ -2,6 +2,9 @@ package fi.jasoft.dragdroplayouts;
 
 import com.vaadin.server.Resource;
 
+/**
+ * Drag caption definition: icon and caption.
+ */
 public class DragCaption {
     protected String caption;
     protected Resource icon;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VDragFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VDragFilter.java
@@ -18,7 +18,6 @@ import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.VCaption;
 import com.vaadin.client.ui.VAccordion.StackItem;
-
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
 
 public class VDragFilter {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
@@ -1,0 +1,59 @@
+package fi.jasoft.dragdroplayouts.client;
+
+import com.google.gwt.user.client.ui.Widget;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.Util;
+import com.vaadin.client.VCaption;
+import com.vaadin.client.ui.VAccordion;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
+
+public class VGrabFilter {
+    private final DDLayoutState state;
+
+    public VGrabFilter(DDLayoutState state) {
+        this.state = state;
+    }
+
+    public boolean isGrabbable(Widget root, Widget widget) {
+        if (state.nonGrabbable != null) {
+            return findConnectorFor(root, widget);
+        }
+        return true;
+    }
+
+    private boolean findConnectorFor(Widget root, Widget widget) {
+        ComponentConnector connector;
+        if (!isCaptionForAccordion(widget)) {
+            connector = Util.findConnectorFor(widget);
+        } else {
+            connector = findConnectorForAccordionCaption(widget);
+        }
+
+        if (connector != null && state.nonGrabbable.contains(connector)) {
+            return false;
+        }
+
+        Widget parent = widget.getParent();
+        if (parent != null && parent == root) {
+            return true;
+        }
+
+        return findConnectorFor(root, parent);
+    }
+
+    private ComponentConnector findConnectorForAccordionCaption(Widget widget) {
+        VAccordion.StackItem parent = (VAccordion.StackItem) widget.getParent();
+        return Util.findConnectorFor(parent.getChildWidget());
+    }
+
+    private boolean isCaptionForAccordion(Widget widget) {
+        if (widget == null) {
+            return false;
+        }
+        if (!(widget instanceof VCaption)) {
+            return false;
+        }
+        Widget parent = widget.getParent();
+        return parent instanceof VAccordion.StackItem;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
@@ -21,20 +21,24 @@ import com.vaadin.client.ui.VAccordion;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
 
 public class VGrabFilter {
-    private final DDLayoutState state;
+    protected final DDLayoutState state;
 
     public VGrabFilter(DDLayoutState state) {
         this.state = state;
     }
 
-    public boolean isGrabbable(Widget root, Widget widget) {
+    public boolean canBeGrabbed(Widget root, Widget widget) {
         if (state.nonGrabbable != null) {
-            return findConnectorFor(root, widget);
+            return canBeGrabbedRecursive(root, widget);
         }
         return true;
     }
 
-    private boolean findConnectorFor(Widget root, Widget widget) {
+    protected boolean canBeGrabbedRecursive(Widget root, Widget widget) {
+        if (widget == root) {
+            return true;
+        }
+
         ComponentConnector connector;
         if (!isCaptionForAccordion(widget)) {
             connector = Util.findConnectorFor(widget);
@@ -47,19 +51,19 @@ public class VGrabFilter {
         }
 
         Widget parent = widget.getParent();
-        if (parent != null && parent == root) {
+        if (parent == null || parent == root) {
             return true;
         }
 
-        return findConnectorFor(root, parent);
+        return canBeGrabbedRecursive(root, parent);
     }
 
-    private ComponentConnector findConnectorForAccordionCaption(Widget widget) {
+    protected ComponentConnector findConnectorForAccordionCaption(Widget widget) {
         VAccordion.StackItem parent = (VAccordion.StackItem) widget.getParent();
         return Util.findConnectorFor(parent.getChildWidget());
     }
 
-    private boolean isCaptionForAccordion(Widget widget) {
+    protected boolean isCaptionForAccordion(Widget widget) {
         if (widget == null) {
             return false;
         }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/VGrabFilter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.client;
 
 import com.google.gwt.user.client.ui.Widget;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/DragCaptionInfo.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/DragCaptionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Nikita Petunin, Yuriy Artamonov
+ * Copyright 2015 Yuriy Artamonov
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,12 +11,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package fi.jasoft.dragdroplayouts.interfaces;
+package fi.jasoft.dragdroplayouts.client.ui;
 
-/**
- * Container that has {@link DragCaptionProvider}.
- */
-public interface HasDragCaptionProvider {
-    void setDragCaptionProvider(DragCaptionProvider provider);
-    DragCaptionProvider getDragCaptionProvider();
+import com.vaadin.shared.ui.ContentMode;
+
+import java.io.Serializable;
+
+public class DragCaptionInfo implements Serializable {
+    public String caption;
+    public String iconKey;
+    public ContentMode contentMode;
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragCaptionProvider.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright 2017 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.client.ui;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.PreElement;
 import com.google.gwt.user.client.ui.Widget;
 import com.vaadin.client.ComponentConnector;
 import com.vaadin.client.Util;
 import com.vaadin.client.ui.AbstractConnector;
 import com.vaadin.client.ui.Icon;
+import com.vaadin.shared.ui.ContentMode;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.DragAndDropAwareState;
 
@@ -20,16 +35,29 @@ public class VDragCaptionProvider {
     public Element getDragCaptionElement(Widget w) {
         ComponentConnector component = Util.findConnectorFor(w);
         DDLayoutState state = ((DragAndDropAwareState) root.getState()).getDragAndDropState();
-        String dragCaptionText = state.dragCaptions.get(component);
+        DragCaptionInfo dci = state.dragCaptions.get(component);
+
         Document document = Document.get();
 
-        Element dragCaptionImage = document.createElement("div");
-        Element dragCaption = document.createElement("span");
-        dragCaption.setInnerText(dragCaptionText);
+        Element dragCaptionImage = document.createDivElement();
+        Element dragCaption = document.createSpanElement();
 
-        String dragIconId = state.dragIcons.get(component);
-        if (dragIconId != null) {
-            String resourceUrl = root.getResourceUrl(dragIconId);
+        String dragCaptionText = dci.caption;
+        if (dragCaptionText != null) {
+            if (dci.contentMode == ContentMode.TEXT) {
+                dragCaption.setInnerText(dragCaptionText);
+            } else if (dci.contentMode == ContentMode.HTML) {
+                dragCaption.setInnerHTML(dragCaptionText);
+            } else if (dci.contentMode == ContentMode.PREFORMATTED) {
+                PreElement preElement = document.createPreElement();
+                preElement.setInnerText(dragCaptionText);
+                dragCaption.appendChild(preElement);
+            }
+        }
+
+        String dragIconKey = state.dragCaptions.get(component).iconKey;
+        if (dragIconKey != null) {
+            String resourceUrl = root.getResourceUrl(dragIconKey);
             Icon icon = component.getConnection().getIcon(resourceUrl);
             dragCaptionImage.appendChild(icon.getElement());
         }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragCaptionProvider.java
@@ -1,0 +1,41 @@
+package fi.jasoft.dragdroplayouts.client.ui;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.Util;
+import com.vaadin.client.ui.AbstractConnector;
+import com.vaadin.client.ui.Icon;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DragAndDropAwareState;
+
+public class VDragCaptionProvider {
+    private final AbstractConnector root;
+
+    public VDragCaptionProvider(AbstractConnector root) {
+        this.root = root;
+    }
+
+    public Element getDragCaptionElement(Widget w) {
+        ComponentConnector component = Util.findConnectorFor(w);
+        DDLayoutState state = ((DragAndDropAwareState) root.getState()).getDragAndDropState();
+        String dragCaptionText = state.dragCaptions.get(component);
+        Document document = Document.get();
+
+        Element dragCaptionImage = document.createElement("div");
+        Element dragCaption = document.createElement("span");
+        dragCaption.setInnerText(dragCaptionText);
+
+        String dragIconId = state.dragIcons.get(component);
+        if (dragIconId != null) {
+            String resourceUrl = root.getResourceUrl(dragIconId);
+            Icon icon = component.getConnection().getIcon(resourceUrl);
+            dragCaptionImage.appendChild(icon.getElement());
+        }
+
+        dragCaptionImage.appendChild(dragCaption);
+
+        return dragCaptionImage;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragDropUtil.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VDragDropUtil.java
@@ -18,17 +18,10 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.user.client.ui.WidgetCollection;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.MouseEventDetailsBuilder;
-import com.vaadin.client.UIDL;
-import com.vaadin.client.Util;
-import com.vaadin.client.VCaption;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.*;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.communication.StateChangeEvent.StateChangeHandler;
-import com.vaadin.client.ui.AbstractComponentConnector;
-import com.vaadin.client.ui.AbstractConnector;
+import com.vaadin.client.ui.*;
 import com.vaadin.client.ui.VAccordion.StackItem;
 import com.vaadin.client.ui.VButton;
 import com.vaadin.client.ui.VFormLayout;
@@ -41,16 +34,10 @@ import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Link;
-
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.accordion.VDDAccordion;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.DragAndDropAwareState;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.tabsheet.VDDTabSheet;
 
 /**
@@ -473,6 +460,18 @@ public final class VDragDropUtil {
                 if (widget instanceof VHasDragFilter) {
                     ((VHasDragFilter) widget)
                             .setDragFilter(new VDragFilter(state));
+                }
+
+                if (widget instanceof VHasGrabFilter) {
+                    ((VHasGrabFilter) widget)
+                            .setGrabFilter(new VGrabFilter(state));
+                }
+
+                if (widget instanceof VHasDragCaptionProvider) {
+                    if (state.dragCaptions.size() > 0) {
+                        ((VHasDragCaptionProvider) widget)
+                                .setDragCaptionProvider(new VDragCaptionProvider(connector));
+                    }
                 }
 
                 if (widget instanceof VHasDragImageReferenceSupport) {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VLayoutDragDropMouseHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VLayoutDragDropMouseHandler.java
@@ -13,15 +13,11 @@
  */
 package fi.jasoft.dragdroplayouts.client.ui;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.EventTarget;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Position;
-import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.dom.client.TouchStartEvent;
@@ -34,33 +30,26 @@ import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.LabelBase;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
-import com.vaadin.client.BrowserInfo;
-import com.vaadin.client.ComponentConnector;
-import com.vaadin.client.Util;
-import com.vaadin.client.VCaption;
-import com.vaadin.client.VConsole;
-import com.vaadin.client.WidgetUtil;
-import com.vaadin.client.ui.VAccordion;
+import com.vaadin.client.*;
+import com.vaadin.client.ui.*;
 import com.vaadin.client.ui.VAccordion.StackItem;
-import com.vaadin.client.ui.VCssLayout;
-import com.vaadin.client.ui.VFormLayout;
-import com.vaadin.client.ui.VPanel;
-import com.vaadin.client.ui.VTabsheet;
 import com.vaadin.client.ui.VTabsheet.Tab;
 import com.vaadin.client.ui.VTabsheet.TabCaption;
 import com.vaadin.client.ui.dd.VDragAndDropManager;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.client.ui.dd.VTransferable;
-
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.accordion.VDDAccordion;
 import fi.jasoft.dragdroplayouts.client.ui.formlayout.VDDFormLayout;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Mouse handler for starting component drag operations
- * 
+ *
  * @author John Ahlroos / www.jasoft.fi
  * @since 0.4.0
  */
@@ -68,6 +57,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
         TouchStartHandler, VHasDragImageReferenceSupport {
 
     public static final String ACTIVE_DRAG_SOURCE_STYLENAME = "v-dd-active-drag-source";
+    public static final String ACTIVE_DRAG_CUSTOM_IMAGE_STYLENAME = "v-dd-active-drag-custom-image";
 
     private LayoutDragMode dragMode = LayoutDragMode.NONE;
 
@@ -95,7 +85,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
     public interface DragStartListener {
         /**
          * Called when a drag is about to begin
-         * 
+         *
          * @param widget
          *            The widget which is about to be dragged
          * @param mode
@@ -107,7 +97,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
     /**
      * Constructor
-     * 
+     *
      * @param root
      *            The root element
      * @param dragMode
@@ -121,7 +111,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
     /**
      * Is the mouse down event a valid mouse drag event, i.e. left mouse button
      * is pressed without any modifier keys
-     * 
+     *
      * @param event
      *            The mouse event
      * @return Is the mouse event a valid drag event
@@ -176,7 +166,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
     /**
      * Initiates the drag only on the first move event
-     * 
+     *
      * @param originalEvent
      *            the original Mouse Down event. Only events on elements are
      *            passed in here (Element.as() is safe without check here)
@@ -209,6 +199,13 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
                         .isDraggable(target) == false &&
 					(target instanceof LabelBase) == false) {
                         stopEventPropagation = false;
+                }
+            }
+
+            if (root instanceof VHasGrabFilter) {
+                VGrabFilter grabFilter = ((VHasGrabFilter) root).getGrabFilter();
+                if (grabFilter != null && !grabFilter.isGrabbable(root, target)) {
+                    return;
                 }
             }
         }
@@ -259,10 +256,10 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
     /**
      * Called when the dragging a component should be initiated by both a mouse
      * down event as well as a touch start event
-     * 
+     *
      * FIXME This method is a BIG hack to circumvent Vaadin's very poor client
      * side API's. This will break often. Refactor once Vaadin gets a grip.
-     * 
+     *
      * @param event
      */
     protected void initiateDrag(NativeEvent event) {
@@ -401,13 +398,31 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
         /*
          * Create the drag image
          */
-        com.google.gwt.dom.client.Element dragImageElement = dragImageProvider == null
-                ? null : dragImageProvider.getDragImageElement(w);
+        boolean hasDragCaption = false;
+
+        com.google.gwt.dom.client.Element dragImageElement = null;
+        if (root instanceof VHasDragCaptionProvider) {
+            VDragCaptionProvider dragCaptionProvider =
+                    ((VHasDragCaptionProvider) root).getDragCaptionProvider();
+            if (dragCaptionProvider != null) {
+                hasDragCaption = true;
+                dragImageElement = dragCaptionProvider
+                        .getDragCaptionElement(currentDraggedWidget);
+            }
+        }
+
+        if (!hasDragCaption && dragImageProvider != null) {
+            dragImageElement = dragImageProvider.getDragImageElement(w);
+        }
 
         if (dragImageElement != null) {
 
             // Set stylename to proxy component as well
-            dragImageElement.addClassName(ACTIVE_DRAG_SOURCE_STYLENAME);
+            if (hasDragCaption) {
+                dragImageElement.addClassName(ACTIVE_DRAG_CUSTOM_IMAGE_STYLENAME);
+            } else {
+                dragImageElement.addClassName(ACTIVE_DRAG_SOURCE_STYLENAME);
+            }
 
         } else if (root instanceof VCssLayout) {
             /*
@@ -450,13 +465,22 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
             dragImageElement = w.getElement();
         }
 
-        currentDragEvent.createDragImage(dragImageElement, true);
-        Element clone = currentDragEvent.getDragImage();
+        Element clone;
+        if (hasDragCaption) {
+            currentDragEvent.setDragImage(dragImageElement);
+            clone = dragImageElement;
+        } else {
+            currentDragEvent.createDragImage(dragImageElement, true);
+            clone = currentDragEvent.getDragImage();
+        }
+
         assert(clone != null);
 
         // Lock drag image dimensions
-        clone.getStyle().setWidth(dragImageElement.getOffsetWidth(), Unit.PX);
-        clone.getStyle().setHeight(dragImageElement.getOffsetHeight(), Unit.PX);
+        if (!hasDragCaption) {
+            clone.getStyle().setWidth(dragImageElement.getOffsetWidth(), Style.Unit.PX);
+            clone.getStyle().setHeight(dragImageElement.getOffsetHeight(), Style.Unit.PX);
+        }
 
         if (c != null && c.delegateCaptionHandling()
                 && !(root instanceof VTabsheet)
@@ -554,7 +578,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
     /**
      * Set the current drag mode
-     * 
+     *
      * @param dragMode
      *            The drag mode to use
      */
@@ -573,7 +597,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
     /**
      * Add a drag start listener to monitor drag starts
-     * 
+     *
      * @param listener
      */
     public void addDragStartListener(DragStartListener listener) {
@@ -582,7 +606,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
     /**
      * Remove a drag start listener
-     * 
+     *
      * @param listener
      */
     public void removeDragStartListener(DragStartListener listener) {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VLayoutDragDropMouseHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/VLayoutDragDropMouseHandler.java
@@ -204,7 +204,7 @@ public class VLayoutDragDropMouseHandler implements MouseDownHandler,
 
             if (root instanceof VHasGrabFilter) {
                 VGrabFilter grabFilter = ((VHasGrabFilter) root).getGrabFilter();
-                if (grabFilter != null && !grabFilter.isGrabbable(root, target)) {
+                if (grabFilter != null && !grabFilter.canBeGrabbed(root, target)) {
                     return;
                 }
             }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/absolutelayout/DDAbsoluteLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/absolutelayout/DDAbsoluteLayoutConnector.java
@@ -18,17 +18,20 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.absolutelayout.AbsoluteLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDAbsoluteLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDAbsoluteLayout.class)
 public class DDAbsoluteLayoutConnector extends AbsoluteLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -86,5 +89,25 @@ public class DDAbsoluteLayoutConnector extends AbsoluteLayoutConnector
     @Override
     public void setDragFilter(VDragFilter filter) {
         getWidget().setDragFilter(filter);
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/absolutelayout/VDDAbsoluteLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/absolutelayout/VDDAbsoluteLayout.java
@@ -20,20 +20,12 @@ import com.vaadin.client.Util;
 import com.vaadin.client.ui.VAbsoluteLayout;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
-
 import fi.jasoft.dragdroplayouts.DDAbsoluteLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -44,7 +36,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
  */
 public class VDDAbsoluteLayout extends VAbsoluteLayout implements VHasDragMode,
         VDDHasDropHandler<VDDAbsoluteLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String CLASSNAME = "v-ddabsolutelayout";
 
@@ -58,6 +50,10 @@ public class VDDAbsoluteLayout extends VAbsoluteLayout implements VHasDragMode,
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
     private LayoutDragMode mode = LayoutDragMode.NONE;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private boolean iframeCovers = false;
 
@@ -242,5 +238,25 @@ public class VDDAbsoluteLayout extends VAbsoluteLayout implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/accordion/DDAccordionConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/accordion/DDAccordionConnector.java
@@ -18,17 +18,20 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.accordion.AccordionConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDAccordion;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDAccordion.class)
 public class DDAccordionConnector extends AccordionConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -43,9 +46,29 @@ public class DDAccordionConnector extends AccordionConnector
     }
 
     @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
     protected void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     public LayoutDragMode getDragMode() {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/accordion/VDDAccordion.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/accordion/VDDAccordion.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts.client.ui.accordion;
 
-import java.util.Map;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
@@ -28,22 +26,15 @@ import com.vaadin.client.ui.VAccordion;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDAccordion;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDTabContainer;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
+
+import java.util.Map;
 
 /**
  * Client side implementation for {@link DDAccordion}
@@ -54,7 +45,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 public class VDDAccordion extends VAccordion
         implements VHasDragMode, VDDHasDropHandler<VDDAccordionDropHandler>,
         DragStartListener, VDDTabContainer, VHasDragFilter,
-        VHasDragImageReferenceSupport, VHasIframeShims {
+        VHasDragImageReferenceSupport, VHasIframeShims, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String CLASSNAME_OVER = "dd-over";
     public static final String CLASSNAME_SPACER = "spacer";
@@ -71,6 +62,10 @@ public class VDDAccordion extends VAccordion
 
     private VDragFilter dragFilter;
 
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
+
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
     private float tabTopBottomDropRatio = DDAccordionState.DEFAULT_VERTICAL_RATIO;
@@ -83,6 +78,16 @@ public class VDDAccordion extends VAccordion
         spacer = GWT.create(HTML.class);
         spacer.setWidth("100%");
         spacer.setStyleName(CLASSNAME_SPACER);
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -403,5 +408,15 @@ public class VDDAccordion extends VAccordion
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/csslayout/DDCssLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/csslayout/DDCssLayoutConnector.java
@@ -18,18 +18,41 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.csslayout.CssLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDCssLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDCssLayout.class)
 public class DDCssLayoutConnector extends CssLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
+    }
 
     @Override
     public VDDCssLayout getWidget() {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/csslayout/VDDCssLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/csslayout/VDDCssLayout.java
@@ -25,20 +25,12 @@ import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDCssLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -50,7 +42,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
  */
 public class VDDCssLayout extends VCssLayout implements VHasDragMode,
         VDDHasDropHandler<VDDCssLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String DRAG_SHADOW_STYLE_NAME = "v-ddcsslayout-drag-shadow";
 
@@ -62,6 +54,10 @@ public class VDDCssLayout extends VCssLayout implements VHasDragMode,
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private double horizontalDropRatio = DDCssLayoutState.DEFAULT_HORIZONTAL_DROP_RATIO;
 
@@ -85,6 +81,16 @@ public class VDDCssLayout extends VCssLayout implements VHasDragMode,
     public boolean dragStart(Widget widget, LayoutDragMode mode) {
         ComponentConnector layout = Util.findConnectorFor(this);
         return VDragDropUtil.isDraggingEnabled(layout, widget);
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     /**
@@ -438,5 +444,15 @@ public class VDDCssLayout extends VCssLayout implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/formlayout/DDFormLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/formlayout/DDFormLayoutConnector.java
@@ -18,16 +18,19 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.formlayout.FormLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDFormLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDFormLayout.class)
 public class DDFormLayoutConnector extends FormLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -42,9 +45,29 @@ public class DDFormLayoutConnector extends FormLayoutConnector
     }
 
     @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
     protected void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/formlayout/VDDFormLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/formlayout/VDDFormLayout.java
@@ -25,20 +25,12 @@ import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.annotations.DelegateToWidget;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDFormLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -49,7 +41,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
  */
 public class VDDFormLayout extends VFormLayout implements VHasDragMode,
         VDDHasDropHandler<VDDFormLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport, VHasGrabFilter, VHasDragCaptionProvider {
 
     private Element currentlyEmphasised;
 
@@ -67,6 +59,10 @@ public class VDDFormLayout extends VFormLayout implements VHasDragMode,
 
     private VDragFilter dragFilter;
 
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
+
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
     protected ApplicationConnection client;
@@ -78,6 +74,16 @@ public class VDDFormLayout extends VFormLayout implements VHasDragMode,
     public VDDFormLayout() {
         super();
         table = (VFormLayoutTable) getWidget();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -362,5 +368,15 @@ public class VDDFormLayout extends VFormLayout implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/DDGridLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/DDGridLayoutConnector.java
@@ -18,16 +18,19 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.gridlayout.GridLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDGridLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDGridLayout.class)
 public class DDGridLayoutConnector extends GridLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -45,6 +48,26 @@ public class DDGridLayoutConnector extends GridLayoutConnector
     public void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     @Override

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/VDDGridLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/gridlayout/VDDGridLayout.java
@@ -13,8 +13,6 @@
  */
 package fi.jasoft.dragdroplayouts.client.ui.gridlayout;
 
-import java.util.Map;
-
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
@@ -30,21 +28,15 @@ import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.HorizontalDropLocation;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDGridLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
+
+import java.util.Map;
 
 /**
  * Client side implementation for {@link DDGridLayout}
@@ -54,7 +46,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
  */
 public class VDDGridLayout extends VGridLayout implements VHasDragMode,
         VDDHasDropHandler<VDDGridLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String CLASSNAME = "v-ddgridlayout";
     public static final String OVER = CLASSNAME + "-over";
@@ -66,6 +58,10 @@ public class VDDGridLayout extends VGridLayout implements VHasDragMode,
     protected ApplicationConnection client;
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -83,6 +79,16 @@ public class VDDGridLayout extends VGridLayout implements VHasDragMode,
 
     public VDDGridLayout() {
         super();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -486,5 +492,15 @@ public class VDDGridLayout extends VGridLayout implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/DDHorizontalLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/DDHorizontalLayoutConnector.java
@@ -18,16 +18,19 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.orderedlayout.HorizontalLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDHorizontalLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDHorizontalLayout.class)
 public class DDHorizontalLayoutConnector extends HorizontalLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -45,6 +48,26 @@ public class DDHorizontalLayoutConnector extends HorizontalLayoutConnector
     public void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontallayout/VDDHorizontalLayout.java
@@ -24,20 +24,12 @@ import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.client.ui.orderedlayout.Slot;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.HorizontalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDHorizontalLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -49,7 +41,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 public class VDDHorizontalLayout extends VHorizontalLayout
         implements VHasDragMode,
         VDDHasDropHandler<VDDHorizontalLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims {
+        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String OVER = "v-ddorderedlayout-over";
     public static final String OVER_SPACED = OVER + "-spaced";
@@ -59,6 +51,10 @@ public class VDDHorizontalLayout extends VHorizontalLayout
     private VDDHorizontalLayoutDropHandler dropHandler;
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -74,6 +70,16 @@ public class VDDHorizontalLayout extends VHorizontalLayout
 
     public VDDHorizontalLayout() {
         super();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -332,5 +338,15 @@ public class VDDHorizontalLayout extends VHorizontalLayout
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontalsplitpanel/DDHorizontalSplitPanelConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontalsplitpanel/DDHorizontalSplitPanelConnector.java
@@ -18,16 +18,20 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.splitpanel.HorizontalSplitPanelConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDHorizontalSplitPanel;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDHorizontalSplitPanel.class)
 public class DDHorizontalSplitPanelConnector extends
-        HorizontalSplitPanelConnector implements Paintable, VHasDragFilter {
+        HorizontalSplitPanelConnector implements Paintable, VHasDragFilter,
+        VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -35,6 +39,26 @@ public class DDHorizontalSplitPanelConnector extends
     protected void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     @Override

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontalsplitpanel/VDDHorizontalSplitPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/horizontalsplitpanel/VDDHorizontalSplitPanel.java
@@ -22,20 +22,12 @@ import com.vaadin.client.ui.VSplitPanelHorizontal;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.HorizontalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDHorizontalSplitPanel;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -47,7 +39,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 public class VDDHorizontalSplitPanel extends VSplitPanelHorizontal implements
         VHasDragMode, VDDHasDropHandler<VDDHorizontalSplitPanelDropHandler>,
         DragStartListener, VHasDragFilter, VHasDragImageReferenceSupport,
-        VHasIframeShims {
+        VHasIframeShims, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String OVER = "v-ddsplitpanel-over";
     public static final String OVER_SPLITTER = OVER + "-splitter";
@@ -64,6 +56,10 @@ public class VDDHorizontalSplitPanel extends VSplitPanelHorizontal implements
 
     private VDragFilter dragFilter;
 
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
+
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
     // The drag mouse handler which handles the creation of the transferable
@@ -76,6 +72,16 @@ public class VDDHorizontalSplitPanel extends VSplitPanelHorizontal implements
 
     public VDDHorizontalSplitPanel() {
         super();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -327,5 +333,15 @@ public class VDDHorizontalSplitPanel extends VSplitPanelHorizontal implements
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/DDLayoutState.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/DDLayoutState.java
@@ -15,6 +15,7 @@ package fi.jasoft.dragdroplayouts.client.ui.interfaces;
 
 import com.vaadin.shared.Connector;
 import com.vaadin.shared.communication.SharedState;
+import fi.jasoft.dragdroplayouts.client.ui.DragCaptionInfo;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 
 import java.util.ArrayList;
@@ -31,15 +32,14 @@ public class DDLayoutState extends SharedState {
     public boolean iframeShims = true;
 
     // Which connectors are draggable
-    public List<Connector> draggable = new ArrayList<Connector>();
+    public List<Connector> draggable = new ArrayList<>();
 
     // Which connectors cannot be used as anchor
-    public List<Connector> nonGrabbable = new ArrayList<Connector>();
+    public List<Connector> nonGrabbable = new ArrayList<>();
 
     // Reference drag images
-    public Map<Connector, Connector> referenceImageComponents = new HashMap<Connector, Connector>();
+    public Map<Connector, Connector> referenceImageComponents = new HashMap<>();
 
-    public Map<Connector, String> dragCaptions = new HashMap<>();
-
-    public Map<Connector, String> dragIcons = new HashMap<>();
+    // Custom DragCaption's with icon and caption
+    public Map<Connector, DragCaptionInfo> dragCaptions = new HashMap<>();
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/DDLayoutState.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/DDLayoutState.java
@@ -13,15 +13,14 @@
  */
 package fi.jasoft.dragdroplayouts.client.ui.interfaces;
 
+import com.vaadin.shared.Connector;
+import com.vaadin.shared.communication.SharedState;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.vaadin.shared.Connector;
-import com.vaadin.shared.communication.SharedState;
-
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 
 public class DDLayoutState extends SharedState {
 
@@ -34,6 +33,13 @@ public class DDLayoutState extends SharedState {
     // Which connectors are draggable
     public List<Connector> draggable = new ArrayList<Connector>();
 
+    // Which connectors cannot be used as anchor
+    public List<Connector> nonGrabbable = new ArrayList<Connector>();
+
     // Reference drag images
     public Map<Connector, Connector> referenceImageComponents = new HashMap<Connector, Connector>();
+
+    public Map<Connector, String> dragCaptions = new HashMap<>();
+
+    public Map<Connector, String> dragIcons = new HashMap<>();
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasDragCaptionProvider.java
@@ -1,0 +1,8 @@
+package fi.jasoft.dragdroplayouts.client.ui.interfaces;
+
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
+
+public interface VHasDragCaptionProvider {
+    void setDragCaptionProvider(VDragCaptionProvider dragCaption);
+    VDragCaptionProvider getDragCaptionProvider();
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasDragCaptionProvider.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.client.ui.interfaces;
 
 import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasGrabFilter.java
@@ -1,0 +1,8 @@
+package fi.jasoft.dragdroplayouts.client.ui.interfaces;
+
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+
+public interface VHasGrabFilter {
+    VGrabFilter getGrabFilter();
+    void setGrabFilter(VGrabFilter grabFilter);
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/interfaces/VHasGrabFilter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.client.ui.interfaces;
 
 import fi.jasoft.dragdroplayouts.client.VGrabFilter;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/DDPanelConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/DDPanelConnector.java
@@ -17,15 +17,19 @@ import com.vaadin.client.ApplicationConnection;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.panel.PanelConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDPanel;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDPanel.class)
-public class DDPanelConnector extends PanelConnector implements VHasDragFilter {
+public class DDPanelConnector extends PanelConnector implements VHasDragFilter,
+        VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -33,6 +37,26 @@ public class DDPanelConnector extends PanelConnector implements VHasDragFilter {
     public void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     @Override

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/VDDPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/panel/VDDPanel.java
@@ -22,24 +22,17 @@ import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.ui.VPanel;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
-
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 public class VDDPanel extends VPanel implements VHasDragMode,
         VDDHasDropHandler<VDDPanelDropHandler>, DragStartListener,
-        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims {
+        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims,
+        VHasGrabFilter, VHasDragCaptionProvider {
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -51,6 +44,10 @@ public class VDDPanel extends VPanel implements VHasDragMode,
             this, LayoutDragMode.NONE);
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private VDDPanelDropHandler dropHandler;
 
@@ -73,6 +70,16 @@ public class VDDPanel extends VPanel implements VHasDragMode,
         ddMouseHandler.updateDragMode(LayoutDragMode.NONE);
         iframeCoverUtility.setIframeCoversEnabled(false, getElement(),
                 LayoutDragMode.NONE);
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -221,5 +228,15 @@ public class VDDPanel extends VPanel implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/tabsheet/DDTabsheetConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/tabsheet/DDTabsheetConnector.java
@@ -18,16 +18,19 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.tabsheet.TabsheetConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDTabSheet;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDTabSheet.class)
 public class DDTabsheetConnector extends TabsheetConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -35,6 +38,26 @@ public class DDTabsheetConnector extends TabsheetConnector
     protected void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     @Override

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/tabsheet/VDDTabSheet.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/tabsheet/VDDTabSheet.java
@@ -26,21 +26,12 @@ import com.vaadin.client.ui.VTabsheetPanel;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.HorizontalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDTabSheet;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDTabContainer;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -52,7 +43,7 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 public class VDDTabSheet extends VTabsheet
         implements VHasDragMode, VDDHasDropHandler<VDDTabsheetDropHandler>,
         DragStartListener, VDDTabContainer, VHasDragFilter,
-        VHasDragImageReferenceSupport, VHasIframeShims {
+        VHasDragImageReferenceSupport, VHasIframeShims, VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String CLASSNAME_NEW_TAB = "new-tab";
     public static final String CLASSNAME_NEW_TAB_LEFT = "new-tab-left";
@@ -71,6 +62,10 @@ public class VDDTabSheet extends VTabsheet
     private final Element newTab = DOM.createDiv();
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -98,6 +93,16 @@ public class VDDTabSheet extends VTabsheet
         Element tBody = tabBar.getElement();
         spacer = tBody.getChild(tBody.getChildCount() - 1).getChild(0)
                 .getChild(0).cast();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -376,5 +381,15 @@ public class VDDTabSheet extends VTabsheet
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/DDVerticalLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/DDVerticalLayoutConnector.java
@@ -18,18 +18,31 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.orderedlayout.VerticalLayoutConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDVerticalLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDVerticalLayout.class)
 public class DDVerticalLayoutConnector extends VerticalLayoutConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
+    }
 
     @Override
     public VDDVerticalLayout getWidget() {
@@ -45,6 +58,16 @@ public class DDVerticalLayoutConnector extends VerticalLayoutConnector
     public void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
     }
 
     public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticallayout/VDDVerticalLayout.java
@@ -24,20 +24,12 @@ import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.client.ui.orderedlayout.Slot;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDVerticalLayout;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -48,7 +40,8 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
  */
 public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
         VDDHasDropHandler<VDDVerticalLayoutDropHandler>, DragStartListener,
-        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport,
+        VHasGrabFilter, VHasDragCaptionProvider {
 
     private Widget currentlyEmphasised;
 
@@ -59,6 +52,10 @@ public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
     private VDDVerticalLayoutDropHandler dropHandler;
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
+
+    private VGrabFilter grabFilter;
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -91,6 +88,16 @@ public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
         ddMouseHandler.updateDragMode(LayoutDragMode.NONE);
         iframeCoverUtility.setIframeCoversEnabled(false, getElement(),
                 LayoutDragMode.NONE);
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     /**
@@ -331,5 +338,15 @@ public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticalsplitpanel/DDVerticalSplitPanelConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticalsplitpanel/DDVerticalSplitPanelConnector.java
@@ -18,16 +18,19 @@ import com.vaadin.client.Paintable;
 import com.vaadin.client.UIDL;
 import com.vaadin.client.ui.splitpanel.VerticalSplitPanelConnector;
 import com.vaadin.shared.ui.Connect;
-
 import fi.jasoft.dragdroplayouts.DDVerticalSplitPanel;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragCaptionProvider;
 import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasGrabFilter;
 import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
 
 @Connect(DDVerticalSplitPanel.class)
 public class DDVerticalSplitPanelConnector extends VerticalSplitPanelConnector
-        implements Paintable, VHasDragFilter {
+        implements Paintable, VHasDragFilter, VHasGrabFilter, VHasDragCaptionProvider {
 
     private HTML5Support html5Support;
 
@@ -35,6 +38,26 @@ public class DDVerticalSplitPanelConnector extends VerticalSplitPanelConnector
     protected void init() {
         super.init();
         VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        getWidget().setDragCaptionProvider(dragCaption);
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return getWidget().getDragCaptionProvider();
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return getWidget().getGrabFilter();
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        getWidget().setGrabFilter(grabFilter);
     }
 
     @Override

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticalsplitpanel/VDDVerticalSplitPanel.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/client/ui/verticalsplitpanel/VDDVerticalSplitPanel.java
@@ -22,20 +22,12 @@ import com.vaadin.client.ui.VSplitPanelVertical;
 import com.vaadin.client.ui.dd.VDragEvent;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.ui.dd.VerticalDropLocation;
-
 import fi.jasoft.dragdroplayouts.DDVerticalSplitPanel;
 import fi.jasoft.dragdroplayouts.client.VDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.Constants;
-import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
-import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.VGrabFilter;
+import fi.jasoft.dragdroplayouts.client.ui.*;
 import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
-import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.*;
 import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 
 /**
@@ -47,13 +39,16 @@ import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
 public class VDDVerticalSplitPanel extends VSplitPanelVertical
         implements VHasDragMode,
         VDDHasDropHandler<VDDVerticalSplitPanelDropHandler>, DragStartListener,
-        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims {
+        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims,
+        VHasGrabFilter, VHasDragCaptionProvider {
 
     public static final String OVER = "v-ddsplitpanel-over";
 
     public static final String OVER_SPLITTER = OVER + "-splitter";
 
     private VDDVerticalSplitPanelDropHandler dropHandler;
+
+    private VGrabFilter grabFilter;
 
     private Element firstContainer;
 
@@ -64,6 +59,8 @@ public class VDDVerticalSplitPanel extends VSplitPanelVertical
     private Element currentEmphasis;
 
     private VDragFilter dragFilter;
+
+    private VDragCaptionProvider dragCaption;
 
     private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
 
@@ -77,6 +74,16 @@ public class VDDVerticalSplitPanel extends VSplitPanelVertical
 
     public VDDVerticalSplitPanel() {
         super();
+    }
+
+    @Override
+    public void setDragCaptionProvider(VDragCaptionProvider dragCaption) {
+        this.dragCaption = dragCaption;
+    }
+
+    @Override
+    public VDragCaptionProvider getDragCaptionProvider() {
+        return dragCaption;
     }
 
     @Override
@@ -323,5 +330,15 @@ public class VDDVerticalSplitPanel extends VSplitPanelVertical
 
     protected final VLayoutDragDropMouseHandler getMouseHandler() {
         return ddMouseHandler;
+    }
+
+    @Override
+    public VGrabFilter getGrabFilter() {
+        return grabFilter;
+    }
+
+    @Override
+    public void setGrabFilter(VGrabFilter grabFilter) {
+        this.grabFilter = grabFilter;
     }
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
@@ -1,0 +1,8 @@
+package fi.jasoft.dragdroplayouts.interfaces;
+
+import com.vaadin.ui.Component;
+import fi.jasoft.dragdroplayouts.DragCaption;
+
+public interface DragCaptionProvider {
+    DragCaption getDragCaption(Component component);
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.interfaces;
 
 import com.vaadin.ui.Component;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
@@ -3,6 +3,11 @@ package fi.jasoft.dragdroplayouts.interfaces;
 import com.vaadin.ui.Component;
 import fi.jasoft.dragdroplayouts.DragCaption;
 
+/**
+ * Interface that provides custom {@link DragCaption} for a child component. <br>
+ * Drag caption is shown as simple DIV with icon and SPAN with caption on client side for a dragged component. <br>
+ * It is the analogue of {@link DragImageProvider} but it does not require additional components for a dragged caption.
+ */
 public interface DragCaptionProvider {
     DragCaption getDragCaption(Component component);
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragCaptionProvider.java
@@ -5,6 +5,7 @@ import fi.jasoft.dragdroplayouts.DragCaption;
 
 /**
  * Interface that provides custom {@link DragCaption} for a child component. <br>
+ * The drag caption will be shown instead of the component when the user drag a component in the layout. <br>
  * Drag caption is shown as simple DIV with icon and SPAN with caption on client side for a dragged component. <br>
  * It is the analogue of {@link DragImageProvider} but it does not require additional components for a dragged caption.
  */

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
@@ -1,0 +1,9 @@
+package fi.jasoft.dragdroplayouts.interfaces;
+
+import com.vaadin.ui.Component;
+
+import java.io.Serializable;
+
+public interface DragGrabFilter extends Serializable {
+    boolean canBeGrabbed(Component component);
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.interfaces;
 
 import com.vaadin.ui.Component;

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilter.java
@@ -4,6 +4,17 @@ import com.vaadin.ui.Component;
 
 import java.io.Serializable;
 
+/**
+ * Grab filter. If filter is set and returned false for some child/nested component then you will not be able to
+ * drag component grabbing this child. E.g. if we have composite Panel inside of some layout that includes Button and
+ * Label you can deny dragging of Panel using Button. <br>
+ *
+ * This feature is similar to {@link DragFilter} but more powerful, since it can filter out deep nested components.
+ */
 public interface DragGrabFilter extends Serializable {
+    /**
+     * @param component nested component (can be deep child of Layout)
+     * @return true if this nested/deep child can be grabbed to drag child component
+     */
     boolean canBeGrabbed(Component component);
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
@@ -1,0 +1,6 @@
+package fi.jasoft.dragdroplayouts.interfaces;
+
+public interface DragGrabFilterSupport {
+    DragGrabFilter getDragGrabFilter();
+    void setDragGrabFilter(DragGrabFilter dragGrabFilter);
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
@@ -1,6 +1,16 @@
 package fi.jasoft.dragdroplayouts.interfaces;
 
+/**
+ * Container that has {@link DragGrabFilter}.
+ */
 public interface DragGrabFilterSupport {
+    /**
+     * @return Drag grab filter
+     */
     DragGrabFilter getDragGrabFilter();
+
+    /**
+     * @param dragGrabFilter drag grab filter
+     */
     void setDragGrabFilter(DragGrabFilter dragGrabFilter);
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/DragGrabFilterSupport.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015 Nikita Petunin, Yuriy Artamonov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package fi.jasoft.dragdroplayouts.interfaces;
 
 /**

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/HasDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/HasDragCaptionProvider.java
@@ -1,7 +1,9 @@
 package fi.jasoft.dragdroplayouts.interfaces;
 
+/**
+ * Container that has {@link DragCaptionProvider}.
+ */
 public interface HasDragCaptionProvider {
-
     void setDragCaptionProvider(DragCaptionProvider provider);
     DragCaptionProvider getDragCaptionProvider();
 }

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/HasDragCaptionProvider.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/interfaces/HasDragCaptionProvider.java
@@ -1,0 +1,7 @@
+package fi.jasoft.dragdroplayouts.interfaces;
+
+public interface HasDragCaptionProvider {
+
+    void setDragCaptionProvider(DragCaptionProvider provider);
+    DragCaptionProvider getDragCaptionProvider();
+}

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
@@ -116,6 +116,7 @@ public class DemoUI extends UI {
             addView(new DragdropAccordionDemo(navigator));
 
             addView(new DragdropDragFilterDemo(navigator));
+            addView(new DragdropDragGrabFilterDemo(navigator));
             addView(new DragdropCaptionModeDemo(navigator));
 
             addView(new DragdropV7VerticalLayoutDemo(navigator));

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
@@ -40,22 +40,7 @@ import de.java2html.javasource.JavaSource;
 import de.java2html.javasource.JavaSourceParser;
 import de.java2html.options.JavaSourceConversionOptions;
 import de.java2html.util.IllegalConfigurationException;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropAbsoluteLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropAccordionDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropCaptionModeDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropCssLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropDragFilterDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropFormLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropGridLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropHorizontalLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropHorizontalSplitPanelDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropLayoutDraggingDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropPanelDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropTabsheetDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropV7HorizontalLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropV7VerticalLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalLayoutDemo;
-import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalSplitPanelDemo;
+import fi.jasoft.dragdroplayouts.demo.views.*;
 
 @Theme("demo")
 public class DemoUI extends UI {
@@ -64,7 +49,7 @@ public class DemoUI extends UI {
 
     private Grid<DemoView> selection;
 
-    private final List<DemoView> views = new ArrayList<DemoView>();
+    private final List<DemoView> views = new ArrayList<>();
 
     private Label codeLabel = new Label("", ContentMode.HTML);
 
@@ -136,8 +121,9 @@ public class DemoUI extends UI {
             addView(new DragdropV7VerticalLayoutDemo(navigator));
             addView(new DragdropV7HorizontalLayoutDemo(navigator));
 
-            // addView(new DragdropIframeDragging(navigator));
+            addView(new DragdropDragCaptionDemo(navigator));
 
+            // addView(new DragdropIframeDragging(navigator));
         } catch (Exception e) {
             e.printStackTrace();
             return;
@@ -160,15 +146,14 @@ public class DemoUI extends UI {
     }
 
     private Grid<DemoView> createViewSelection() {
-
         Grid<DemoView> select = new Grid<>();
 
         select.addColumn(view -> view.getCaption());
         select.setWidth("200px");
         select.setHeight("100%");
-        select.addSelectionListener((change) -> {
-            navigator.navigateTo(change.getFirstSelectedItem().get().getName());
-        });
+        select.addSelectionListener((change) ->
+                navigator.navigateTo(change.getFirstSelectedItem().get().getName())
+        );
 
         select.setItems(views);
         return select;

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragCaptionDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragCaptionDemo.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.demo.views;
+
+import com.vaadin.icons.VaadinIcons;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.shared.ui.ContentMode;
+import com.vaadin.ui.*;
+import fi.jasoft.dragdroplayouts.DDPanel;
+import fi.jasoft.dragdroplayouts.DragCaption;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.demo.DemoView;
+import fi.jasoft.dragdroplayouts.drophandlers.DefaultPanelDropHandler;
+
+public class DragdropDragCaptionDemo extends DemoView {
+
+    public static final String NAME = "dd-caption";
+
+    public DragdropDragCaptionDemo(Navigator navigator) {
+        super(navigator);
+    }
+
+    @Override
+    public Component getLayout() {
+        // start-source
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.setSizeFull();
+        layout.setMargin(true);
+        layout.setSpacing(true);
+
+        DDPanel panel1 = new DDPanel("Source");
+        panel1.setWidth("200px");
+        panel1.setHeight("200px");
+        panel1.setDragMode(LayoutDragMode.CLONE);
+        panel1.setDropHandler(new DefaultPanelDropHandler());
+
+        panel1.setDragCaptionProvider(component ->
+                new DragCaption("Custom drag caption for "
+                        + component.getClass().getSimpleName(), VaadinIcons.AIRPLANE));
+
+        layout.addComponent(panel1);
+
+        Button content = new Button("Drag me!");
+        content.setSizeFull();
+        panel1.setContent(content);
+
+        DDPanel panel2 = new DDPanel("Destination");
+        panel2.setWidth("200px");
+        panel2.setHeight("200px");
+        panel2.setDragMode(LayoutDragMode.CLONE);
+        panel2.setDropHandler(new DefaultPanelDropHandler());
+
+        panel2.setDragCaptionProvider(component ->
+                new DragCaption("Drag caption goes back! "
+                        + component.getClass().getSimpleName(), VaadinIcons.AIRPLANE));
+
+        layout.addComponent(panel2);
+
+        // end-source
+        Label label = new Label(
+                "In this demo you can drag the button." +
+                        "\nYou will see custom drag caption(with icon) provided by DragCaptionProvider");
+        label.setContentMode(ContentMode.PREFORMATTED);
+        return new VerticalLayout(
+                label,
+                layout);
+    }
+
+    @Override
+    public String getCaption() {
+        return "DragCaption";
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragCaptionDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragCaptionDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 John Ahlroos
+ * Copyright 2015 Yuriy Artamonov
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -46,8 +46,11 @@ public class DragdropDragCaptionDemo extends DemoView {
         panel1.setDropHandler(new DefaultPanelDropHandler());
 
         panel1.setDragCaptionProvider(component ->
-                new DragCaption("Custom drag caption for "
-                        + component.getClass().getSimpleName(), VaadinIcons.AIRPLANE));
+                new DragCaption(
+                        "<u>Custom drag caption:</u><br/>" + component.getClass().getSimpleName(),
+                        VaadinIcons.AIRPLANE,
+                        ContentMode.HTML)
+        );
 
         layout.addComponent(panel1);
 

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragGrabFilterDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragGrabFilterDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 John Ahlroos
+ * Copyright 2015 Yuriy Artamonov
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragGrabFilterDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropDragGrabFilterDemo.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.demo.views;
+
+import com.vaadin.navigator.Navigator;
+import com.vaadin.ui.*;
+import fi.jasoft.dragdroplayouts.DDAbsoluteLayout;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.demo.DemoView;
+import fi.jasoft.dragdroplayouts.drophandlers.DefaultAbsoluteLayoutDropHandler;
+import fi.jasoft.dragdroplayouts.interfaces.DragGrabFilter;
+
+public class DragdropDragGrabFilterDemo extends DemoView {
+
+    public static final String NAME = "dd-grab-filters";
+
+    public DragdropDragGrabFilterDemo(Navigator navigator) {
+        super(navigator);
+    }
+
+    @Override
+    public Component getLayout() {
+        // start-source
+        // Create an absolute layout
+        DDAbsoluteLayout layout = new DDAbsoluteLayout();
+        layout.setSizeFull();
+
+        // Enable dragging (of all) components
+        layout.setDragMode(LayoutDragMode.CLONE);
+
+        // Limit dragging to only buttons
+        layout.setDragGrabFilter((DragGrabFilter) component -> {
+            // Button/TextField inside of draggable Panel cannot be used/grabbed for Drag-n-Drop.
+            return !(component instanceof Button)
+                    && !(component instanceof TextField);
+        });
+
+        // Enable dropping components
+        layout.setDropHandler(new DefaultAbsoluteLayoutDropHandler());
+
+        // Add some components to layout
+        Label label = new Label("DragGrabFilter enable you to control which nested components of draggable " +
+                "child can be used/grabbed. All components in this example are composite and draggable, " +
+                "but you cannot drag Panel using Button/TextField children");
+        label.setWidth("650px");
+        layout.addComponent(label);
+
+        layout.addComponent(createCompositeChild("1"), "left:50px;top:100px");
+        layout.addComponent(createCompositeChild("3"), "left:280px;top:100px");
+        layout.addComponent(createCompositeChild("3"), "left:510px;top:100px");
+
+        // end-source
+        return layout;
+    }
+
+    private Panel createCompositeChild(String caption) {
+        Panel compositePanel = new Panel();
+        compositePanel.setWidthUndefined();
+        compositePanel.setCaption("Composite Widget " + caption);
+
+        VerticalLayout content = new VerticalLayout();
+        content.setWidthUndefined();
+        compositePanel.setContent(content);
+
+        content.addComponent(new Label("Grab me to drag Panel"));
+        content.addComponent(new Button("Cannot be grabbed"));
+        content.addComponent(new TextField("Cannot be grabbed TextField"));
+        content.addComponent(new Label("Grab me too!"));
+
+        for (int i = 0; i < content.getComponentCount(); i++) {
+            content.getComponent(i).setWidth(100, Unit.PERCENTAGE);
+        }
+
+        return compositePanel;
+    }
+
+    @Override
+    public String getCaption() {
+        return "DragGrab filters";
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}


### PR DESCRIPTION
* Introduced DragGrabFilter that can filter inner components of a container from "grabbing" on client-side. It enables us to disable dragging container by grabbing its inner components, e.g. we can prevent dragging of VerticalLayout if a user grabs inner Table.
* Implemented DragCaptionProvider that can be used to show simple DOM element with icon and caption instead of copy of dragged component. DragCaptionProvider must return DragCaption POJO for each draggable component inside of a container.

See demos: DragdropDragCaptionDemo and DragdropDragGrabFilterDemo

Please review, will merge it next week it if there are no comments / issues